### PR TITLE
Remove faulty Server Actor (Master Server Address)

### DIFF
--- a/files/Scripts/prepare.py
+++ b/files/Scripts/prepare.py
@@ -45,7 +45,6 @@ def initial_setup():
     set_config_value(utIniFileServer, 'IpServer.UdpServerUplink', 'MasterServerPort', '27900')
     ## Add server visibility in server browser inside game by adding correct URLs
     set_config_value(utIniFileServer, 'Engine.GameEngine', 'ServerActors', 'IpServer.UdpServerUplink MasterServerAddress=utmaster.epicgames.com MasterServerPort=27900', True)
-    set_config_value(utIniFileServer, 'Engine.GameEngine', 'ServerActors', 'IpServer.UdpServerUplink MasterServerAddress=master.noccer.de MasterServerPort=27900', True)
     set_config_value(utIniFileServer, 'Engine.GameEngine', 'ServerActors', 'IpServer.UdpServerUplink MasterServerAddress=master.333networks.com MasterServerPort=27900', True)
 
     # Add Mutators


### PR DESCRIPTION
It causes the error on the server startup: 
```
Game engine initialized
UDP recvfrom error: 11 from 0.0.0.0:0
Signal: SIGSEGV [segmentation fault]
Aborting.
Exiting.
Name subsystem shut down
Allocation checking disabled
/startup.sh: line 7:     7 Segmentation fault      (core dumped) /ut-server/ucc server $UT_SERVERURL ini=UnrealTournament.ini log=ut.log -nohomedir -lanplay
```