### PR TITLE
Allow custom User.ini and avoid duplicate file presence in named volume errors

### DIFF
--- a/files/Scripts/prepare.py
+++ b/files/Scripts/prepare.py
@@ -8,6 +8,8 @@ utDataPath = "/ut-data"
 folders = ["Maps", "Music", "Sounds", "System", "Textures"]
 utIniFileServer = f"/{utServerPath}/System/UnrealTournament.ini"
 utIniFileData = f"/{utDataPath}/System/UnrealTournament.ini"
+userIniFileServer = f"/{utServerPath}/System/User.ini"
+userIniFileData = f"/{utDataPath}/System/User.ini"
 
 def main():
     if len(sys.argv) >= 2 and sys.argv[1] == "i":
@@ -68,6 +70,7 @@ def initial_setup():
 
     # Move and/or symlink the original ini files
     move_and_symlink(utIniFileServer, utIniFileData)
+    move_and_symlink(userIniFileServer, userIniFileData)
 
     # Fix some file cases (to prevent a warning)
     os.rename(f"/{utServerPath}/System/BotPack.u", f"/{utServerPath}/System/Botpack.u")
@@ -94,7 +97,8 @@ def prepare():
             fullFilePath = os.path.join(folderPath, entry)
             print(f'[L] {os.path.join(folder, entry)}')
             targetPath = os.path.join(utServerPath, folder, entry)
-            os.symlink(fullFilePath, targetPath)
+            if not (os.path.lexists(targetPath)):
+                os.symlink(fullFilePath, targetPath)
 
     # Update some config values according to optional environment variables
     ## Enable the web admin and set username/password
@@ -112,7 +116,7 @@ def prepare():
     set_config_to_environment('UT_GAMEPWD', utIniFileServer, 'Engine.GameInfo', 'GamePassword')
 
 def move_and_symlink(fileSrc, fileDest):
-    os.rename(fileSrc, fileDest)
+    os.replace(fileSrc, fileDest)
     symlink(fileDest, fileSrc)
 
 def symlink(fileSrc, fileDest):


### PR DESCRIPTION
1. Modification of `User.ini` allows users to have custom bot names, skins, voices, and playstyles for their server.
2. Duplication of some files can cause errors (file already exists) in `prepare.py`. Modificatoins here allow lazy loading, for example,  placing a copy of a map in the `Maps` subdirectory of the named volume which is already in default unreal tounrament will not cause `prepare.py` to break.