### PR TITLE
Fixed overwriting of patched file Botpack.u

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,7 @@
 version: "3.9"
 services:
   ut99-server:
-    build:
-      - context: ./files
-      - dockerfile: Dockerfile
+    build: .
     image: roemer/ut99-server:latest
     volumes:
       - ut99-data:/ut-data

--- a/files/Scripts/prepare.py
+++ b/files/Scripts/prepare.py
@@ -75,7 +75,7 @@ def initial_setup():
     move_and_symlink(userIniFileServer, userIniFileData)
 
     # Fix some file cases (to prevent a warning)
-    os.rename(f"/{utServerPath}/System/BotPack.u", f"/{utServerPath}/System/Botpack.u")
+#    os.rename(f"/{utServerPath}/System/BotPack.u", f"/{utServerPath}/System/Botpack.u")
     os.rename(f"/{utServerPath}/Textures/UTcrypt.utx", f"/{utServerPath}/Textures/utcrypt.utx")
     os.rename(f"/{utServerPath}/Textures/GenFluid.utx", f"/{utServerPath}/Textures/genfluid.utx")
     os.rename(f"/{utServerPath}/Textures/Soldierskins.utx", f"/{utServerPath}/Textures/SoldierSkins.utx")


### PR DESCRIPTION
File Botpack.u included in the 469b patch is no longer overwritten by the original file included in the 436 server package as mentioned in  #11.