### PR TITLE
removed deprecated version tag from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   ut99-server:
     image: roemer/ut99-server:latest


### PR DESCRIPTION
The version tag in the docker-compose.yml is obsolete and issues a warning when I use docker compose. 

That's why I removed it.