### PR TITLE
Update to version 469e

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM amd64/ubuntu:latest
 
 # Original Server v436
 ADD files/ut-server-linux-436.tar.gz /
-# Update to 469c
-ADD files/Patches/OldUnreal-UTPatch469d-Linux-x86.tar.bz2 /ut-server/
+# Update to 469e
+ADD files/Patches/OldUnreal-UTPatch469e-Linux-x86.tar.bz2 /ut-server/
 # Fix for broken maps from the original file
 ADD files/Patches/BrokenMapsFix.tar.gz /ut-server/
 # Add the bonus packs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/ubuntu:latest
+FROM debian:13-slim
 
 # Original Server v436
 ADD files/ut-server-linux-436.tar.gz /


### PR DESCRIPTION
OldUnreal released a [new version](https://github.com/OldUnreal/UnrealTournamentPatches/releases/tag/v469e) of their patch!

I switched the 469d version in the repo for the newer release.
Afterwards the Dockerfile did not build with a failure related to the `FROM` tag.
Switching the base image to Debian 13 slim worked without a hitch however.

---
Complete aside: I accidentally built the docker image for ARM initially and that worked fine. Debian multiarch support was really flawless. Probably better to run a dedicated ARM build but better than no image I guess.
If the images are on [my docker hub](https://hub.docker.com/r/michaelem/ut99-server/tags).
The command to build both architectures was:
```
docker buildx build --platform linux/amd64,linux/arm64 -t michaelem/ut99-server .
```
